### PR TITLE
Clear the submit field after submitting a file

### DIFF
--- a/app/assets/javascripts/assessments_show.coffee
+++ b/app/assets/javascripts/assessments_show.coffee
@@ -7,3 +7,4 @@ $('#handin_show_assessment #fake-submit').click (e)->
 # On file pick, we submit the form automatically
 $("input[type='file']").change (e)->
 	$('#handin_show_assessment #new_submission').submit()
+	$("#handin_show_assessment input[type='file']").val("")  # clear for re-selecting the same file


### PR DESCRIPTION
Summary:
This is good practice for submit forms in general,
because it makes the Back button work properly
(and re-selections in general).
The Autolab-specific workflow is as follows.
Frequently, I submit a file,
then immediately remember some minor changes
(as one does).
So I let it submit, then hit "Back,"
then open the submit file dialog again.
But now the file is already selected,
so if I select it again no change event is fired.
The solution is to just clear the value.

Test Plan:
**I have not tested this change to the CoffeeScript file.**
What I did do was to enter the line that I added
into the Chrome JS console,
then click the Submit File button and submit a file,
then click Back and submit the same file again.
This worked.
So the JS is fine;
the question is whether I integrated it properly with Autolab.